### PR TITLE
POC for iframe-based smoke tests

### DIFF
--- a/src/_phantomjs.js
+++ b/src/_phantomjs.js
@@ -10,7 +10,7 @@
 		console.log("CONSOLE: " + message);
 	};
 
-	page.open("http://localhost:5000", function(success) {
+	page.open("http://app.weewikipaint.com:5000", function(success) {
 		try {
 			var error = page.evaluate(inBrowser);
 			if (error) {

--- a/src/client/_smoke_test.js
+++ b/src/client/_smoke_test.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2012 Titanium I.T. LLC.	rights reserved. See LICENSE.txt for details.
+/*global Raphael, mocha, Touch, $, before, after */
+
+(function() {
+	"use strict";
+
+	describe("Smoke tests", function() {
+		var iframe, app;
+
+		before(function(done) {
+			var frameName = "app";
+
+			iframe = document.createElement("iframe");
+			iframe.id = frameName;
+			iframe.src = "http://app.weewikipaint.com:5001/";
+			iframe.onload = function() {
+				done();
+			};
+
+			document.body.appendChild(iframe);
+			app = frames[frameName];
+
+			document.domain = "weewikipaint.com";
+		});
+
+		it("should have wwp & friends defined", function() {
+			expect(typeof app.wwp).not.to.equal("undefined");
+		});
+
+		after(function() {
+			document.body.removeChild(iframe);
+		});
+	});
+}());

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -176,6 +176,8 @@
 </div>
 
 <script type="text/javascript">
+    document.domain = "weewikipaint.com";
+
     $(function() {
         wwp.drawingAreaCanvas = wwp.initializeDrawingArea(new wwp.HtmlElement($("#drawingArea")));
     });


### PR DESCRIPTION
PREREQUISITES

Since Karma runs its own server we are not able to access the app in an
iframe due to the same origin policy. To get around this we have to put
both the application and the Karma test runner on subdomains of the same
second-level domain, for example app.weewikipaint.com and
tests.weewikipaint.com, and set document.domain = "weewikipaint.com" in
both of them.

Then, in src/client/_smoke_test.js, we inject an iframe in the Karma test
runner’s context and load the app in it. Then we get a handle to the app
and check things out.