### PR TITLE
PhantomJS exits with correct code when fonts fail to load

### DIFF
--- a/src/_phantomjs.js
+++ b/src/_phantomjs.js
@@ -28,7 +28,9 @@
 						console.log("error", error);
 						phantom.exit(1);
 					}
-					phantom.exit(0);
+					else {
+						phantom.exit(0);
+					}
 				}, 10000);
 			}
 		}


### PR DESCRIPTION
It seems that you can't call `phantom.exit()` twice in a row.
