### PR TITLE
Remove the need for a timeout in smoke test for font loading

### DIFF
--- a/src/_phantomjs.js
+++ b/src/_phantomjs.js
@@ -16,16 +16,17 @@
 
 	page.onInitialized = function () {
 		page.evaluate(function () {
+			var typekitConfig = window.__typekitConfig = {};
 			var fonts = [];
 
-			window.__fontactive = function (family, variant) {
+			typekitConfig.fontactive = function fontactive(family, variant) {
 				fonts.push({
 					family: family,
 					variant: variant
 				});
 			};
 
-			window.__done = function () {
+			typekitConfig.active = typekitConfig.inactive = function done() {
 				window.callPhantom(fonts);
 			};
 		});

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -11,17 +11,14 @@
 
     <script>
         (function(d) {
-            var noop = function(){};
-            var config = {
-                kitId: 'qzr7zlc',
-                scriptTimeout: 3000,
-                active: window.__done || noop,
-                inactive: window.__done || noop,
-                fontactive: window.__fontactive || noop
-            },
-            h = d.documentElement,
+            var config = window.__typekitConfig || {};
+            config.kitId = 'qzr7zlc';
+            config.scriptTimeout = 3000;
+
+            var h = d.documentElement,
             t = setTimeout(function() {
                 h.className = h.className.replace(/\bwf-loading\b/g, "") + " wf-inactive";
+                if (typeof config.inactive === "function") config.inactive();
             }, config.scriptTimeout),
             tk = d.createElement("script"),
             f = false,


### PR DESCRIPTION
I wired up the font loading events to PhantomJS.
- The callback `onInitialized` is called _before_ the page is loaded (especially before the IIFE with the TypeKit boilerplate is executed).
- It defines callbacks for `fontactive` and `done` in the browser's global namespace. The loaded fonts get stored in a local array. When `done` is called PhantomJS is notified via `callPhantom` (which is provided by PhantomJS).
- `callPhantom` triggers `page.onCallback` with the collected fonts array as argument (Note: only serializable data can be exchanged this way).
- On the client side, the callbacks that are defined via PhantomJS are assigned to the config object (or a no-op function if they are undefined, which will be the case outside of the smoke test).

**Remaining problems**
- The test does not feel terribly faster. I don't know if there are any PhantomJS settings or other tweaks that would improve this.
- The call to `phantom.exit()` is now within `onCallback` which is less than ideal. Either should there be a mechanism for collecting asynchronous test results or each test should go into its own file. The former is probably better for performance (because of spawning less processes) while the latter is generally simpler and makes it easier to organize the tests.
