### PR TITLE
Issue7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ node_modules/karma/node_modules/socket.io/node_modules/socket.io-client/node_mod
 # Selenium WebDriverJS: Optional dependencies that don't build on vanilla Windows
 node_modules/selenium-webdriver/node_modules/ws/node_modules/bufferutil/
 node_modules/selenium-webdriver/node_modules/ws/node_modules/utf-8-validate/
+
+
+
+# Maas Sublime ignores
+*.sublime-project
+*.sublime-workspace

--- a/src/_run_server.js
+++ b/src/_run_server.js
@@ -10,12 +10,19 @@
 		return run("inherit");
 	};
 
-	exports.runProgrammatically = function(callback) {
-		var serverProcess = run(["pipe", "pipe", process.stderr]);
+	exports.runProgrammatically = function(callback, errorCallback) {
+		var serverProcess = run(["pipe", "pipe", "pipe"]);
 
 		serverProcess.stdout.setEncoding("utf8");
 		serverProcess.stdout.on("data", function(chunk) {
 			if (chunk.trim().indexOf("Server started") !== -1) callback(serverProcess);
+		});
+
+		serverProcess.stderr.setEncoding("utf8");
+		serverProcess.stderr.on("data", function(chunk) {
+			var proc = parseProcFile();
+			var error = new Error("Spawning '" + proc.command + " " + proc.options + "' failed.");
+			errorCallback(error);
 		});
 	};
 

--- a/src/_smoke_test.js
+++ b/src/_smoke_test.js
@@ -23,7 +23,6 @@
 		before(function (done) {
 			runServer.runProgrammatically(function(process) {
 				serverProcess = process;
-
 				driver = new firefox.Driver();
 				driver.getCapabilities().then(function(capabilities) {
 					var version = capabilities.get("browserName") + " " + capabilities.get("version");
@@ -32,10 +31,12 @@
 					}
 					done();
 				});
-			});
+			}, done);
 		});
 
 		after(function(done) {
+			if (serverProcess === undefined)
+				return done();
 			serverProcess.on("exit", function(code, signal) {
 				driver.quit().then(done);
 			});


### PR DESCRIPTION
This fixes the bad error message when the server port is already occupied, but it doesn't address the real problem with firefox and selenium.

The firefox/selenium-bug seems to be hard to get by. Selenium crashes with a SIGSEGV and gives mocha no chance to clean up. I can't see a simple way to try/catch that in nodejs either. https://github.com/ddopson/node-segfault-handler created a module that writes a stack-trace when nodejs dies, but that module doesn't make any attempt to stop the actual core-dump.