### PR TITLE
RealTimeServer.disconnectAll() implemented.

### DIFF
--- a/src/server/_real_time_server_test.js
+++ b/src/server/_real_time_server_test.js
@@ -35,22 +35,10 @@
 			httpServer.start(PORT, done);
 		});
 
-		afterEach(function(done) {
-			waitForConnectionCount(0, "afterEach() requires all sockets to be closed", function() {
-				httpServer.stop(done);
-			});
-		});
-
-		it("counts the number of connections", function(done) {
-			assert.equal(realTimeServer.numberOfActiveConnections(), 0, "before opening connection");
-
-			var socket = createSocket();
-			waitForConnectionCount(1, "after opening connection", function() {
-				assert.equal(realTimeServer.numberOfActiveConnections(), 1, "after opening connection");
-				closeSocket(socket, function() {
-					waitForConnectionCount(0, "after closing connection", done);
-				});
-			});
+        afterEach(function(done) {
+            realTimeServer.disconnectAll(function () {
+                httpServer.stop(done);
+            });
 		});
 
 		it("broadcasts pointer events from one client to all others", function(done) {
@@ -89,8 +77,8 @@
 
 			realTimeServer.handleClientEvent(clientEvent, EMITTER_ID);
 
-			function end() {
-				async.each([ receiver1, receiver2 ], closeSocket, done);
+            function end() {
+                setTimeout(done, 0);
 			}
 		});
 
@@ -111,18 +99,16 @@
 			client.on(ServerDrawEvent.EVENT_NAME, function(event) {
 				replayedEvents.push(ServerDrawEvent.fromSerializableObject(event));
 				if (replayedEvents.length === 3) {
-					try {
-						// if we don't get the events, the test will time out
-						assert.deepEqual(replayedEvents, [
-							event1.toServerEvent(),
-							event2.toServerEvent(),
-							event3.toServerEvent()
-						]);
-					}
-					finally {
-						closeSocket(client, done);
-					}
-				}
+
+					// if we don't get the events, the test will time out
+					assert.deepEqual(replayedEvents, [
+						event1.toServerEvent(),
+						event2.toServerEvent(),
+						event3.toServerEvent()
+                    ]);
+
+                    setTimeout(done, 10);
+			    }
 			});
 		});
 
@@ -144,28 +130,10 @@
 						next();
 					}
 				});
-			}, end);
+			}, done);
 
 			emitter.emit(clientEvent.name(), clientEvent.toSerializableObject());
-
-			function end() {
-				async.each([emitter, receiver1, receiver2], closeSocket, done);
-			}
-		}
-
-		function waitForConnectionCount(expectedConnections, message, callback) {
-			var TIMEOUT = 1000; // milliseconds
-			var RETRY_PERIOD = 10; // milliseconds
-
-			var retryOptions = { times: TIMEOUT / RETRY_PERIOD, interval: RETRY_PERIOD };
-			async.retry(retryOptions, function(next) {
-				if (realTimeServer.numberOfActiveConnections() === expectedConnections) return next();
-				else return next("fail");
-			}, function(err) {
-				if (err) return assert.equal(realTimeServer.numberOfActiveConnections(), expectedConnections, message);
-				else setTimeout(callback, 0);
-			});
-		}
+        }
 
 		function createSocket() {
 			return io("http://localhost:" + PORT);

--- a/src/server/_server_test.js
+++ b/src/server/_server_test.js
@@ -65,14 +65,10 @@
 
 			receiver.on(ServerPointerEvent.EVENT_NAME, function(data) {
 				assert.deepEqual(data, clientEvent.toServerEvent(emitter.id).toSerializableObject());
-				end();
+                setTimeout(done, 10);
 			});
 
 			emitter.emit(clientEvent.name(), clientEvent.toSerializableObject());
-
-			function end() {
-				async.each([ emitter, receiver ], closeSocket, done);
-			}
 		});
 
 		function createSocket() {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,14 +13,17 @@
 		this._httpServer = new HttpServer(contentDir, notFoundPageToServe);
 		this._httpServer.start(portNumber, callback);
 
-		var realTimeServer = new RealTimeServer();
-		realTimeServer.start(this._httpServer.getNodeServer());
+		this._realTimeServer = new RealTimeServer();
+		this._realTimeServer.start(this._httpServer.getNodeServer());
 	};
 
-	Server.prototype.stop = function(callback) {
-		if (this._httpServer === undefined) return callback(new Error("stop() called before server started"));
+    Server.prototype.stop = function (callback) {
+        var self = this;
+		if (self._httpServer === undefined) return callback(new Error("stop() called before server started"));
 
-		this._httpServer.stop(callback);
+        self._realTimeServer.disconnectAll(function () {
+            self._httpServer.stop(callback);
+        });
 	};
 
 }());


### PR DESCRIPTION
I suggest rewriting the cleanup logic to ask RealTimeServer to disconnect all open sockets before stopping the http server.

This code is still somewhat a hack, because I don't quite understand why I need some setTimeout() wrappers around done, but I still think this is a lot better. Also the private variable RealTimeServer._disconnectAllCallback can be debated, but doing it like this we can keep numberOfActiveConnections() as a private method without explicit testing.

This is my preferred PR of 3 to improve the shutdown logic.