### PR TITLE
Rts stop 2

### DIFF
--- a/src/server/_server_test.js
+++ b/src/server/_server_test.js
@@ -65,14 +65,10 @@
 
 			receiver.on(ServerPointerEvent.EVENT_NAME, function(data) {
 				assert.deepEqual(data, clientEvent.toServerEvent(emitter.id).toSerializableObject());
-				end();
+                setTimeout(done, 10);
 			});
 
 			emitter.emit(clientEvent.name(), clientEvent.toSerializableObject());
-
-			function end() {
-				async.each([ emitter, receiver ], closeSocket, done);
-			}
 		});
 
 		function createSocket() {

--- a/src/server/real_time_server.js
+++ b/src/server/real_time_server.js
@@ -2,7 +2,8 @@
 (function() {
 	"use strict";
 
-	var io = require('socket.io');
+    var io = require('socket.io');
+    var async = require('async');
 	var ClientPointerEvent = require("../shared/client_pointer_event.js");
 	var ClientRemovePointerEvent = require("../shared/client_remove_pointer_event.js");
 	var ClientDrawEvent = require("../shared/client_draw_event.js");
@@ -33,7 +34,19 @@
 
 	RealTimeServer.prototype.numberOfActiveConnections = function() {
 		return Object.keys(this._socketIoConnections).length;
-	};
+    };
+
+    RealTimeServer.prototype.disconnectAll = function (callback) {
+        if (this.numberOfActiveConnections() === 0) {
+            if (callback) callback();
+        }
+        else {
+            if (callback)
+                this.once('disconnect_all', callback);
+
+            async.each(this._socketIoConnections, function (socket) { socket.disconnect(); });
+        }
+    };
 
 	function trackSocketIoConnections(connections, ioServer, self) {
 		// Inspired by isaacs https://github.com/isaacs/server-destroy/commit/71f1a988e1b05c395e879b18b850713d1774fa92

--- a/src/server/real_time_server.js
+++ b/src/server/real_time_server.js
@@ -8,6 +8,7 @@
 	var ClientDrawEvent = require("../shared/client_draw_event.js");
 	var ClientClearScreenEvent = require("../shared/client_clear_screen_event.js");
 	var EventRepository = require("./event_repository.js");
+    var EventEmitter = require("../client/network/vendor/emitter-1.2.1.js");
 
 	// Consider Jay Bazuzi's suggestions from E494 comments (direct connection from client to server when testing)
 	// http://disq.us/p/1gobws6  http://www.letscodejavascript.com/v3/comments/live/494
@@ -16,10 +17,12 @@
 		this._socketIoConnections = {};
 	};
 
+    RealTimeServer.prototype = Object.create(EventEmitter.prototype);
+
 	RealTimeServer.prototype.start = function(httpServer) {
 		this._ioServer = io(httpServer);
 
-		trackSocketIoConnections(this._socketIoConnections, this._ioServer);
+		trackSocketIoConnections(this._socketIoConnections, this._ioServer, this);
 		handleSocketIoEvents(this, this._ioServer);
 	};
 
@@ -32,13 +35,19 @@
 		return Object.keys(this._socketIoConnections).length;
 	};
 
-	function trackSocketIoConnections(connections, ioServer) {
+	function trackSocketIoConnections(connections, ioServer, self) {
 		// Inspired by isaacs https://github.com/isaacs/server-destroy/commit/71f1a988e1b05c395e879b18b850713d1774fa92
 		ioServer.on("connection", function(socket) {
 			var key = socket.id;
 			connections[key] = socket;
-			socket.on("disconnect", function() {
+			self.emit('connection', key);
+
+            socket.on("disconnect", function () {
 				delete connections[key];
+                self.emit('disconnect', key);
+
+                if (self.numberOfActiveConnections() === 0)
+                    self.emit('disconnect_all');
 			});
 		});
 	}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,14 +13,17 @@
 		this._httpServer = new HttpServer(contentDir, notFoundPageToServe);
 		this._httpServer.start(portNumber, callback);
 
-		var realTimeServer = new RealTimeServer();
-		realTimeServer.start(this._httpServer.getNodeServer());
+		this._realTimeServer = new RealTimeServer();
+		this._realTimeServer.start(this._httpServer.getNodeServer());
 	};
 
-	Server.prototype.stop = function(callback) {
-		if (this._httpServer === undefined) return callback(new Error("stop() called before server started"));
+    Server.prototype.stop = function (callback) {
+        var self = this;
+		if (self._httpServer === undefined) return callback(new Error("stop() called before server started"));
 
-		this._httpServer.stop(callback);
+        self._realTimeServer.disconnectAll(function () {
+            self._httpServer.stop(callback);
+        });
 	};
 
 }());


### PR DESCRIPTION
This is an alternative PR to RTS-stop-3, where RealTimeServer extends the EventEmitter class we previously used in the client. Use this solution for calling the disconnectAll callback if you don't like the private variable used in PR RTS-stop-3.
