### PR TITLE
Replaced waitForConnectionCount() with just a disconnect_all event.

### DIFF
--- a/src/server/_real_time_server_test.js
+++ b/src/server/_real_time_server_test.js
@@ -35,23 +35,24 @@
 			httpServer.start(PORT, done);
 		});
 
-		afterEach(function(done) {
-			waitForConnectionCount(0, "afterEach() requires all sockets to be closed", function() {
-				httpServer.stop(done);
-			});
+        afterEach(function(done) {
+			assert.equal(realTimeServer.numberOfActiveConnections(), 0, "afterEach() requires all sockets to be closed");
+            httpServer.stop(done);
 		});
 
-		it("counts the number of connections", function(done) {
-			assert.equal(realTimeServer.numberOfActiveConnections(), 0, "before opening connection");
+        it("emits event when all sockets have disconnected", function (done) {
+            var isAfterDisconnect = false;
+            realTimeServer.on('disconnect_all', function () {
+                assert.equal(isAfterDisconnect, true, "after closing connection");
+                done();
+            });
 
-			var socket = createSocket();
-			waitForConnectionCount(1, "after opening connection", function() {
-				assert.equal(realTimeServer.numberOfActiveConnections(), 1, "after opening connection");
-				closeSocket(socket, function() {
-					waitForConnectionCount(0, "after closing connection", done);
-				});
-			});
-		});
+            var socket = createSocket();
+            socket.on('connect', function () {
+                socket.disconnect();
+                isAfterDisconnect = true;
+            });
+        });
 
 		it("broadcasts pointer events from one client to all others", function(done) {
 			checkEventReflection(new ClientPointerEvent(100, 200), ServerPointerEvent, done);
@@ -89,8 +90,8 @@
 
 			realTimeServer.handleClientEvent(clientEvent, EMITTER_ID);
 
-			function end() {
-				async.each([ receiver1, receiver2 ], closeSocket, done);
+            function end() {
+                disconnectAll([receiver1, receiver2], done);
 			}
 		});
 
@@ -119,8 +120,8 @@
 							event3.toServerEvent()
 						]);
 					}
-					finally {
-						closeSocket(client, done);
+                    finally {
+                        disconnectAll([client], done);
 					}
 				}
 			});
@@ -148,24 +149,15 @@
 
 			emitter.emit(clientEvent.name(), clientEvent.toSerializableObject());
 
-			function end() {
-				async.each([emitter, receiver1, receiver2], closeSocket, done);
+            function end() {
+                disconnectAll([emitter, receiver1, receiver2], done);
 			}
-		}
+        }
 
-		function waitForConnectionCount(expectedConnections, message, callback) {
-			var TIMEOUT = 1000; // milliseconds
-			var RETRY_PERIOD = 10; // milliseconds
-
-			var retryOptions = { times: TIMEOUT / RETRY_PERIOD, interval: RETRY_PERIOD };
-			async.retry(retryOptions, function(next) {
-				if (realTimeServer.numberOfActiveConnections() === expectedConnections) return next();
-				else return next("fail");
-			}, function(err) {
-				if (err) return assert.equal(realTimeServer.numberOfActiveConnections(), expectedConnections, message);
-				else setTimeout(callback, 0);
-			});
-		}
+        function disconnectAll(sockets, callback) {
+            realTimeServer.once('disconnect_all', callback);
+            async.each(sockets, function (socket) { socket.disconnect(); });
+        }
 
 		function createSocket() {
 			return io("http://localhost:" + PORT);

--- a/src/server/real_time_server.js
+++ b/src/server/real_time_server.js
@@ -8,6 +8,7 @@
 	var ClientDrawEvent = require("../shared/client_draw_event.js");
 	var ClientClearScreenEvent = require("../shared/client_clear_screen_event.js");
 	var EventRepository = require("./event_repository.js");
+    var EventEmitter = require("../client/network/vendor/emitter-1.2.1.js");
 
 	// Consider Jay Bazuzi's suggestions from E494 comments (direct connection from client to server when testing)
 	// http://disq.us/p/1gobws6  http://www.letscodejavascript.com/v3/comments/live/494
@@ -16,10 +17,12 @@
 		this._socketIoConnections = {};
 	};
 
+    RealTimeServer.prototype = Object.create(EventEmitter.prototype);
+
 	RealTimeServer.prototype.start = function(httpServer) {
 		this._ioServer = io(httpServer);
 
-		trackSocketIoConnections(this._socketIoConnections, this._ioServer);
+		trackSocketIoConnections(this._socketIoConnections, this._ioServer, this);
 		handleSocketIoEvents(this, this._ioServer);
 	};
 
@@ -32,13 +35,16 @@
 		return Object.keys(this._socketIoConnections).length;
 	};
 
-	function trackSocketIoConnections(connections, ioServer) {
+	function trackSocketIoConnections(connections, ioServer, self) {
 		// Inspired by isaacs https://github.com/isaacs/server-destroy/commit/71f1a988e1b05c395e879b18b850713d1774fa92
 		ioServer.on("connection", function(socket) {
 			var key = socket.id;
 			connections[key] = socket;
-			socket.on("disconnect", function() {
+            socket.on("disconnect", function() {
 				delete connections[key];
+
+                if (self.numberOfActiveConnections() === 0)
+                    self.emit('disconnect_all');
 			});
 		});
 	}


### PR DESCRIPTION
RTS-stop-1 is the simplest approach to removing the function waitForConnectionCount() and my least favorable. It uses the EventEmitter from RTS-stop-2 to make RealTimeServer emit events when sockets connect and disconnect, but all tests are still required to properly shut down their sockets.

Use this if neither of the other two PRs are acceptable.