### PR TITLE
Fix socket.io race condition

### DIFF
--- a/src/server/_real_time_server_test.js
+++ b/src/server/_real_time_server_test.js
@@ -71,11 +71,12 @@
 		it("counts the number of connections", function(done) {
 			assert.equal(realTimeServer.numberOfActiveConnections(), 0, "before opening connection");
 
-			var socket = createSocket();
-			waitForConnectionCount(1, "after opening connection", function() {
-				assert.equal(realTimeServer.numberOfActiveConnections(), 1, "after opening connection");
-				closeSocket(socket, function() {
-					waitForConnectionCount(0, "after closing connection", done);
+			createSocket(function (socket) {
+				waitForConnectionCount(1, "after opening connection", function() {
+					assert.equal(realTimeServer.numberOfActiveConnections(), 1, "after opening connection");
+					closeSocket(socket, function() {
+						waitForConnectionCount(0, "after closing connection", done);
+					});
 				});
 			});
 		});
@@ -94,13 +95,14 @@
 			});
 		}
 
-		function createSocket() {
-			return io("http://localhost:" + PORT);
+		function createSocket(callback) {
+			var socket = io("http://localhost:" + PORT);
+			socket.on("connect", function () { callback(socket); });
 		}
 
 		function closeSocket(socket, callback) {
+			socket.on("disconnect", callback);
 			socket.disconnect();
-			callback();
 		}
 
 		function createTestFile(fileAndData, done) {

--- a/src/server/_real_time_server_test.js
+++ b/src/server/_real_time_server_test.js
@@ -12,6 +12,7 @@
 	var IRRELEVANT_PAGE = "irrelevant.html";
 
 	var PORT = 5020;
+	var SERVER_TIMEOUT = 500; // milliseconds
 
 	describe("RealTimeServer", function() {
 		var httpServer;
@@ -22,10 +23,13 @@
 			realTimeServer = new RealTimeServer();
 
 			realTimeServer.start(httpServer.getNodeServer());
+			httpServer._httpServer.setTimeout(SERVER_TIMEOUT);
 			httpServer.start(PORT, done);
 		});
 
 		afterEach(function(done) {
+			this.timeout(2 * SERVER_TIMEOUT);
+
 			waitForConnectionCount(0, "afterEach() requires all sockets to be closed", function() {
 				httpServer.stop(done);
 			});

--- a/src/server/_real_time_server_test.js
+++ b/src/server/_real_time_server_test.js
@@ -4,50 +4,18 @@
 
 	var RealTimeServer = require("./real_time_server.js");
 	var HttpServer = require("./http_server.js");
-	var http = require("http");
-	var fs = require("fs");
 	var async = require("async");
 	var assert = require("_assert");
 	var io = require("socket.io-client");
-
-	var CONTENT_DIR = "generated/test";
-
-	var INDEX_PAGE = "index.html";
-	var OTHER_PAGE = "other.html";
-	var NOT_FOUND_PAGE = "test404.html";
-
-	var INDEX_PAGE_DATA = "This is index page file";
-	var OTHER_PAGE_DATA = "This is another page";
-	var NOT_FOUND_DATA = "This is 404 page file";
-
-
 
 	var IRRELEVANT_DIR = "generated/test";
 	var IRRELEVANT_PAGE = "irrelevant.html";
 
 	var PORT = 5020;
-	var BASE_URL = "http://localhost:" + PORT;
-
-	var TEST_FILES = [
-		[ CONTENT_DIR + "/" + INDEX_PAGE, INDEX_PAGE_DATA],
-		[ CONTENT_DIR + "/" + OTHER_PAGE, OTHER_PAGE_DATA],
-		[ CONTENT_DIR + "/" + NOT_FOUND_PAGE, NOT_FOUND_DATA]
-	];
 
 	describe("RealTimeServer", function() {
 		var httpServer;
 		var realTimeServer;
-
-
-		beforeEach(function(done) {
-			async.each(TEST_FILES, createTestFile, done);
-		});
-
-		afterEach(function(done) {
-			async.each(TEST_FILES, deleteTestFile, done);
-		});
-
-
 
 		beforeEach(function(done) {
 			httpServer = new HttpServer(IRRELEVANT_DIR, IRRELEVANT_PAGE);
@@ -61,11 +29,6 @@
 			waitForConnectionCount(0, "afterEach() requires all sockets to be closed", function() {
 				httpServer.stop(done);
 			});
-		});
-
-		it("delay", function(done) {
-			this.timeout(10000);
-			setTimeout(done, 0);
 		});
 
 		it("counts the number of connections", function(done) {
@@ -104,33 +67,5 @@
 			socket.on("disconnect", callback);
 			socket.disconnect();
 		}
-
-		function createTestFile(fileAndData, done) {
-			// Note: writeFile() MUST be called asynchronously in order for this code to work on Windows 7.
-			// If it's called synchronously, it fails with an EPERM error when the second test starts. This
-			// may be related to this Node.js issue: https://github.com/joyent/node/issues/6599
-			// This issue appeared after upgrading send 0.2.0 to 0.9.3. Prior to that, writeFileSync()
-			// worked fine.
-			fs.writeFile(fileAndData[0], fileAndData[1], function(err) {
-				if (err) console.log("could not create test file: [" + fileAndData[0] + "]. Error: " + err);
-				done();
-			});
-		}
-
-		function deleteTestFile(fileAndData, done) {
-			// Note: unlink() MUST be called asynchronously here in order for this code to work on Windows 7.
-			// If it's called synchronously, then it will run before the file is closed, and that is not allowed
-			// on Windows 7. It's possible that this is the result of a Node.js bug; see this issue for details:
-			// https://github.com/joyent/node/issues/6599
-			var file = fileAndData[0];
-			if (fs.existsSync(file)) {
-				fs.unlink(file, function(err) {
-					if (err || fs.existsSync(file)) console.log("could not delete test file: [" + file + "]. Error: " + err);
-					done();
-				});
-			}
-		}
-
 	});
-
 }());


### PR DESCRIPTION
I think this solves the race condition with socket.io. I basically did two things:
- Make `createSocket` asynchronous so that it ensures that the new socket is actually connected. This made the tests a lot more stable.
- Set a timeout for the underlying HTTP server. After removing all the other code the HTTP server did not shut down reliably. After poking around using [`getConnections()`](https://nodejs.org/api/net.html#net_server_getconnections_callback) I found that occasionally there is a connection hanging there, preventing `done()` to be called. I resolved this by setting a [timeout](https://nodejs.org/api/http.html#http_server_settimeout_msecs_callback) on the HTTP server to forcefully shut down all hanging connections.