### PR TITLE
socket_io_abstraction wraps emitted arguments in a single object.

### DIFF
--- a/src/server/_socket_io_abstraction_test.js
+++ b/src/server/_socket_io_abstraction_test.js
@@ -54,14 +54,12 @@
 		it("emits event when a client connects", async function() {
 			let socket;
 
-			const eventPromise = new Promise((resolve, reject) => {
-				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_CONNECT, (clientId) => {
-					resolve(clientId);
-				});
+			const eventPromise = new Promise((resolve) => {
+				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_CONNECT, resolve);
 			});
 
 			socket = await socketIoClient.createSocket();
-			const clientId = await eventPromise;
+			const { clientId } = await eventPromise;
 			assert.equal(clientId, socket.id, "client ID");
 
 			await socketIoClient.closeSocket(socket);
@@ -71,14 +69,12 @@
 			const socket = await socketIoClient.createSocket();
 			const socketId = socket.id;
 
-			const eventPromise = new Promise((resolve, reject) => {
-				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_DISCONNECT, (clientId) => {
-					resolve(clientId);
-				});
+			const eventPromise = new Promise((resolve) => {
+				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_DISCONNECT, resolve);
 			});
 
 			await socketIoClient.closeSocket(socket);
-			const clientId = await eventPromise;
+			const { clientId } = await eventPromise;
 			assert.equal(clientId, socketId, "client ID");
 		});
 
@@ -86,10 +82,8 @@
 			const socket = await socketIoClient.createSocket();
 			const eventToSend = new ClientRemovePointerEvent();
 
-			const eventPromise = new Promise((resolve, reject) => {
-				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, (clientId, receivedEvent) => {
-					resolve({ clientId, receivedEvent });
-				});
+			const eventPromise = new Promise((resolve) => {
+				socketIoAbstraction.once(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, resolve);
 			});
 
 			socket.emit(eventToSend.name(), eventToSend.payload());
@@ -170,10 +164,8 @@
 		});
 
 		function listenForOneClientSocketEvent(socket, event) {
-			return new Promise((resolve, reject) => {
-				socket.once(event.name(), (eventPayload) => {
-					resolve(eventPayload);
-				});
+			return new Promise((resolve) => {
+				socket.once(event.name(), resolve);
 			});
 		}
 

--- a/src/server/real_time_server.js
+++ b/src/server/real_time_server.js
@@ -62,7 +62,7 @@
 	RealTimeServer.CLIENT_TIMEOUT = CLIENT_TIMEOUT;
 
 	function handleRealTimeEvents(self) {
-		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_CONNECT, (clientId) => {
+		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_CONNECT, ({ clientId }) => {
 			replayPreviousEvents(self, clientId);
 			handleClientEvents(self);
 
@@ -85,7 +85,7 @@
 			});
 		}, 100);
 
-		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_CONNECT, (clientId) => {
+		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_CONNECT, ({ clientId }) => {
 			self._lastActivity[clientId] = self._clock.now();
 
 			self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, () => {
@@ -105,8 +105,8 @@
 	}
 
 	function handleClientEvents(self) {
-		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, (clientId, clientEvent) => {
-			processClientEvent(self, clientId, clientEvent);
+		self._socketIoAbstraction.on(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, (args) => {
+			processClientEvent(self, args.clientId, args.receivedEvent);
 		});
 	}
 

--- a/src/server/socket_io_abstraction.js
+++ b/src/server/socket_io_abstraction.js
@@ -76,21 +76,25 @@
 		// Inspired by isaacs
 		// https://github.com/isaacs/server-destroy/commit/71f1a988e1b05c395e879b18b850713d1774fa92
 		ioServer.on("connection", function(socket) {
-			const key = socket.id;
-			connections[key] = socket;
+			const clientId = socket.id;
+			connections[clientId] = socket;
 			socket.on("disconnect", function() {
-				delete connections[key];
-				self.emit(SocketIoAbstraction.CLIENT_DISCONNECT, key);
+				delete connections[clientId];
+				self.emit(SocketIoAbstraction.CLIENT_DISCONNECT, { clientId });
 			});
-			self.emit(SocketIoAbstraction.CLIENT_CONNECT, key, socket);
+			self.emit(SocketIoAbstraction.CLIENT_CONNECT, { clientId });
 		});
-	}
+    }
 
 	function listenForClientEvents(self, ioServer) {
 		ioServer.on("connect", (socket) => {
 			SUPPORTED_EVENTS.forEach(function(eventConstructor) {
 				socket.on(eventConstructor.EVENT_NAME, function(payload) {
-					self.emit(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, socket.id, eventConstructor.fromPayload(payload));
+					let args = {
+						clientId: socket.id,
+						receivedEvent: eventConstructor.fromPayload(payload)
+					};
+					self.emit(SocketIoAbstraction.CLIENT_EVENT_RECEIVED, args);
 				});
 			});
 		});


### PR DESCRIPTION
Here is my suggestion on how to streamline the emitter in E584.

This is simple enough, but it's up to coding style if you like to wrap single arguments in an object too, like I do here, or if you prefer to sometimes emit an integer and at other times emit an object.

As always you do as you like with this code.. :)